### PR TITLE
Fof test

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,13 +8,12 @@ ANCHOR= -DANCHOR_ALGO
 #ANCHOR= 
 PROFILE= -DPROFILING
 CHARMC = $(CHARM_DIR)/bin/charmc $(PROFILE) #$(ANCHOR)
-OPTS = -std=c++11 -O0 -g #was -03
+OPTS = -std=c++11 -O3 -g
 LD_OPTS =
-# CK_TEMPLATES = -DCK_TEMPLATES_ONLY
 
 #options for building union-find library and prefix library
 PREFIX_LIBS = -L${PREFIX_LIB_DIR} -lprefix
-PREFIX_INC = -I${PREFIX_LIB_DIR} # ${CK_TEMPLATES}
+PREFIX_INC = -I${PREFIX_LIB_DIR}
 
 UNION_FIND_LIBS = -L${UNION_FIND_DIR} -lunionFind ${PREFIX_LIBS}
 UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC} 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,19 +1,20 @@
 #set the following variables to absolute paths
-CHARM_DIR = /Users/raghu/work/charm/charm
-UNION_FIND_DIR = /Users/raghu/work/charm/unionFind/unionFind
+CHARM_DIR = /Users/johnnychen/Documents/Projects/research/charm
+UNION_FIND_DIR = /Users/johnnychen/Documents/Projects/research/unionfind
 PREFIX_LIB_DIR = $(UNION_FIND_DIR)/prefixLib
 
 #charmc options
 ANCHOR= -DANCHOR_ALGO
 #ANCHOR= 
 PROFILE= -DPROFILING
-CHARMC = $(CHARM_DIR)/bin/charmc $(ANCHOR) $(PROFILE)
-OPTS = -std=c++11 -O3 -g
+CHARMC = $(CHARM_DIR)/bin/charmc $(PROFILE) #$(ANCHOR)
+OPTS = -std=c++11 -O0 -g #was -03
 LD_OPTS =
+# CK_TEMPLATES = -DCK_TEMPLATES_ONLY
 
 #options for building union-find library and prefix library
 PREFIX_LIBS = -L${PREFIX_LIB_DIR} -lprefix
-PREFIX_INC = -I${PREFIX_LIB_DIR}
+PREFIX_INC = -I${PREFIX_LIB_DIR} # ${CK_TEMPLATES}
 
 UNION_FIND_LIBS = -L${UNION_FIND_DIR} -lunionFind ${PREFIX_LIBS}
-UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC}
+UNION_FIND_INC = -I${UNION_FIND_DIR} ${PREFIX_INC} 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,6 +1,6 @@
 #set the following variables to absolute paths
-CHARM_DIR = /Users/johnnychen/Documents/Projects/research/charm
-UNION_FIND_DIR = /Users/johnnychen/Documents/Projects/research/unionfind
+CHARM_DIR = $(HOME)/Documents/nbodydir/charm
+UNION_FIND_DIR = $(HOME)/Documents/nbodydir/unionfind
 PREFIX_LIB_DIR = $(UNION_FIND_DIR)/prefixLib
 
 #charmc options

--- a/examples/simple_graph/graph.C
+++ b/examples/simple_graph/graph.C
@@ -147,7 +147,7 @@ class TreePiece : public CBase_TreePiece {
         libPtr = libProxy[thisIndex].ckLocal();
         libPtr->initialize_vertices(libVertices, numMyVertices);
         libPtr->registerGetLocationFromID(getLocationFromID);
-        contribute(CkCallback(CkReductionTarget(Main, startWork), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, Main::startWork), mainProxy));
     }
 
     void doWork() {
@@ -172,7 +172,7 @@ class TreePiece : public CBase_TreePiece {
                 CkAbort("Something wrong in inverted-tree construction!\n");
             }
         }
-        contribute(CkCallback(CkReductionTarget(Main, donePrinting), mainProxy));
+        contribute(CkCallback(CkReductionTarget(Main, Main::donePrinting), mainProxy));
     }
 
     void getConnectedComponents() {

--- a/prefixLib/Makefile
+++ b/prefixLib/Makefile
@@ -3,7 +3,7 @@ CHARMC=/Users/raghu/work/charm/charm/bin/charmc $(OPTS)
 all: libprefix.a
 
 libprefix.a: prefixBalance.o
-	$(CHARMC) prefixBalance.o -o libprefix.a -language charm++
+	$(CHARMC) prefixBalance.o -o libprefix.a -language charm++ # -DCK_TEMPLATES_ONLY
 
 prefixBalance.o : prefixBalance.C prefixBalance.def.h prefixBalance.decl.h
 	$(CHARMC) -c prefixBalance.C

--- a/prefixLib/Makefile
+++ b/prefixLib/Makefile
@@ -1,4 +1,4 @@
-CHARMC=/Users/raghu/work/charm/charm/bin/charmc $(OPTS)
+include ../Makefile.common
 
 all: libprefix.a
 

--- a/types.h
+++ b/types.h
@@ -26,7 +26,7 @@ struct anchorData {
 
 struct shortCircuitData {
     uint64_t arrIdx;
-    uint64_t grandparentID;
+    int64_t grandparentID;
 
     void pup(PUP::er &p) {
         p|arrIdx;

--- a/types.h
+++ b/types.h
@@ -12,6 +12,16 @@ struct findBossData {
     }
 };
 
+struct needBossData {
+    uint64_t arrIdx;
+    uint64_t senderID;
+
+    void pup(PUP::er &p) {
+        p|arrIdx;
+        p|senderID;
+    }
+};
+
 #ifdef ANCHOR_ALGO
 struct anchorData {
     uint64_t arrIdx;

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -100,7 +100,6 @@ initialize_vertices(unionFindVertex *appVertices, int numVertices) {
 #ifndef ANCHOR_ALGO
 void UnionFindLib::
 union_request(uint64_t vid1, uint64_t vid2) {
-    CkPrintf("[unionfind] union_request on %llu, %llu\n", v, w);
     assert(vid1!=vid2);
     if (vid2 < vid1) {
         // found a back edge, flip and reprocess
@@ -127,7 +126,6 @@ union_request(uint64_t vid1, uint64_t vid2) {
 #else
 void UnionFindLib::
 union_request(uint64_t v, uint64_t w) {
-    CkPrintf("[unionfind] union_request on %llu, %llu\n", v, w);
     std::pair<int, int> w_loc = getLocationFromID(w);
     // message w to anchor to v
     anchorData d;

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -564,9 +564,9 @@ set_component(int arrIdx, long int compNum) {
     myVertices[arrIdx].componentNumber = compNum;
 
     // since component number is set, respond to your requestors
-    std::vector<uint64_t>::iterator req_iter = myVertices[arrIdx].need_boss_requests.begin();
-    while (req_iter != myVertices[arrIdx].need_boss_requests.end()) {
-        uint64_t requestorID = *req_iter;
+    std::vector<uint64_t> need_boss_queue = myVertices[arrIdx].need_boss_requests;
+    while (!need_boss_queue.empty()) {
+        uint64_t requestorID = (need_boss_queue).back();
         std::pair<int, int> requestor_loc = getLocationFromID(requestorID);
         if (requestor_loc.first == thisIndex) {
             set_component(requestor_loc.second, compNum);
@@ -574,7 +574,7 @@ set_component(int arrIdx, long int compNum) {
             this->thisProxy[requestor_loc.first].set_component(requestor_loc.second, compNum);
         }
         // done with current requestor, delete from request queue
-        req_iter = myVertices[arrIdx].need_boss_requests.erase(req_iter);
+        need_boss_queue.pop_back();
     }
 }
 

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -116,7 +116,15 @@ union_request(uint64_t vid1, uint64_t vid2) {
         d.partnerOrBossID = vid2;
         d.senderID = -1;
         d.isFBOne = 1;
-        this->thisProxy[vid1_loc.first].insertDataFindBoss(d);
+        if(vid1_loc.first == this->thisIndex)
+        {
+            this->insertDataFindBoss(d);
+        }
+        else
+        {
+            this->thisProxy[vid1_loc.first].insertDataFindBoss(d);
+        }
+
 
         //for profiling
         CProxy_UnionFindLibGroup libGroup(libGroupID);
@@ -153,7 +161,15 @@ find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID) {
         d.partnerOrBossID = src->vertexID;
         d.senderID = -1;
         d.isFBOne = 0;
-        this->thisProxy[partner_loc.first].insertDataFindBoss(d);
+        if(partner_loc.first == this->thisIndex)
+        {
+            insertDataFindBoss(d);
+        }
+        else
+        {
+            this->thisProxy[partner_loc.first].insertDataFindBoss(d);
+        }
+        
 
         CProxy_UnionFindLibGroup libGroup(libGroupID);
         libGroup.ckLocalBranch()->increase_message_count();

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -153,6 +153,7 @@ find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID) {
         d.partnerOrBossID = src->vertexID;
         d.senderID = -1;
         d.isFBOne = 0;
+        //CkPrintf("partner_loc.first is %d and partnerID is %lu and arrIdx is %d\n", partner_loc.first,partnerID,arrIdx);
         this->thisProxy[partner_loc.first].insertDataFindBoss(d);
 
         CProxy_UnionFindLibGroup libGroup(libGroupID);
@@ -695,7 +696,8 @@ profiling_count_max(long int maxCount) {
 // library group chare class definitions
 void UnionFindLibGroup::
 build_component_count_array(int *totalCounts, int numElems) {
-    //CkPrintf("[PE %d] Count array size: %d\n", thisIndex, numElems);
+    
+    CkPrintf("[PE %d] Count array size: %d\n", thisIndex, numElems);
     component_count_array = new int[numElems];
     memcpy(component_count_array, totalCounts, sizeof(int)*numElems);
     contribute(CkCallback(CkReductionTarget(UnionFindLib, perform_pruning), _UfLibProxy));
@@ -751,7 +753,17 @@ unionFindInit(CkArrayID clientArray, int n) {
     prefixLibArray = CProxy_Prefix::ckNew(n, prefix_opts);
 
     libGroupID = CProxy_UnionFindLibGroup::ckNew();
+
+    _UfLibProxy.passLibGroupID(libGroupID, prefixLibArray);
+
     return _UfLibProxy;
+}
+
+void UnionFindLib::passLibGroupID(CkGroupID lgid, CProxy_Prefix pla)
+{
+    prefixLibArray = pla;
+    libGroupID = lgid;
+    _UfLibProxy = this->thisProxy;
 }
 
 #include "unionFindLib.def.h"

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -153,7 +153,6 @@ find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID) {
         d.partnerOrBossID = src->vertexID;
         d.senderID = -1;
         d.isFBOne = 0;
-        //CkPrintf("partner_loc.first is %d and partnerID is %lu and arrIdx is %d\n", partner_loc.first,partnerID,arrIdx);
         this->thisProxy[partner_loc.first].insertDataFindBoss(d);
 
         CProxy_UnionFindLibGroup libGroup(libGroupID);

--- a/unionFindLib.C
+++ b/unionFindLib.C
@@ -696,7 +696,7 @@ profiling_count_max(long int maxCount) {
 void UnionFindLibGroup::
 build_component_count_array(int *totalCounts, int numElems) {
     
-    CkPrintf("[PE %d] Count array size: %d\n", thisIndex, numElems);
+    //CkPrintf("[PE %d] Count array size: %d\n", thisIndex, numElems);
     component_count_array = new int[numElems];
     memcpy(component_count_array, totalCounts, sizeof(int)*numElems);
     contribute(CkCallback(CkReductionTarget(UnionFindLib, perform_pruning), _UfLibProxy));

--- a/unionFindLib.ci
+++ b/unionFindLib.ci
@@ -18,13 +18,13 @@ module unionFindLib {
         entry void find_boss1(int arrIdx, uint64_t partnerID, uint64_t initID);
         entry void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t initID);
 #else
-        entry void anchor(int w_arrIdx, long v, long path_base_arrIdx);
+        entry void anchor(int w_arrIdx, uint64_t v, long path_base_arrIdx);
 #endif
         // function for grandparent short-circuiting
         entry [aggregate] void short_circuit_parent(shortCircuitData scd);
 
         // function for path compression support
-        entry void compress_path(int arrIdx, int64_t compressedParent);
+        entry void compress_path(int arrIdx, uint64_t compressedParent);
 
         // functions to perform distributed connected components
         entry void find_components(CkCallback cb);

--- a/unionFindLib.ci
+++ b/unionFindLib.ci
@@ -15,8 +15,8 @@ module unionFindLib {
         entry void register_phase_one_cb(CkCallback cb);
         // functions to build inverted trees
 #ifndef ANCHOR_ALGO
-        entry void find_boss1(int arrIdx, long partnerID, long initID);
-        entry void find_boss2(int arrIdx, long boss1ID, long initID);
+        entry void find_boss1(int arrIdx, uint64_t partnerID, uint64_t initID);
+        entry void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t initID);
 #else
         entry void anchor(int w_arrIdx, long v, long path_base_arrIdx);
 #endif
@@ -24,12 +24,12 @@ module unionFindLib {
         entry [aggregate] void short_circuit_parent(shortCircuitData scd);
 
         // function for path compression support
-        entry void compress_path(int arrIdx, long compressedParent);
+        entry void compress_path(int arrIdx, int64_t compressedParent);
 
         // functions to perform distributed connected components
         entry void find_components(CkCallback cb);
         entry [reductiontarget] void boss_count_prefix_done(int totalCount);
-        entry void need_boss(int arrIdx, int fromID);
+        entry void need_boss(int arrIdx, uint64_t fromID);
         entry void set_component(int arrIdx, int compNum);
 
         // functions to prune out small components
@@ -40,7 +40,7 @@ module unionFindLib {
 
         // TRAM functions
         entry [aggregate] void insertDataFindBoss(const findBossData & data);
-        entry [aggregate] void insertDataNeedBoss(const uint64_t & data);
+        entry [aggregate] void insertDataNeedBoss(const needBossData & data);
 #ifdef ANCHOR_ALGO
         entry [aggregate] void insertDataAnchor(const anchorData & data);
 #endif

--- a/unionFindLib.ci
+++ b/unionFindLib.ci
@@ -11,6 +11,11 @@ module unionFindLib {
 
     array[1D] UnionFindLib {
         entry UnionFindLib();
+
+        
+        entry void passLibGroupID(CkGroupID lgid, CProxy_Prefix pla);
+
+
         // function to register Phase 1 callback
         entry void register_phase_one_cb(CkCallback cb);
         // functions to build inverted trees
@@ -39,10 +44,10 @@ module unionFindLib {
         //entry [reductiontarget] void merge_count_results(int totalCounts[numElems], int numElems);
 
         // TRAM functions
-        entry [aggregate] void insertDataFindBoss(const findBossData & data);
-        entry [aggregate] void insertDataNeedBoss(const needBossData & data);
+        entry void insertDataFindBoss(const findBossData & data);
+        entry void insertDataNeedBoss(const needBossData & data);
 #ifdef ANCHOR_ALGO
-        entry [aggregate] void insertDataAnchor(const anchorData & data);
+        entry void insertDataAnchor(const anchorData & data);
 #endif
 #ifdef PROFILING
         entry [reductiontarget] void profiling_count_max(long maxCount);
@@ -55,5 +60,6 @@ module unionFindLib {
         entry [reductiontarget] void build_component_count_array(int totalCounts[numElems], int numElems);
         entry [reductiontarget] void done_profiling(int result);
         entry void contribute_count();
+
     }
 };

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -58,13 +58,13 @@ class UnionFindLib : public CBase_UnionFindLib {
     void find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID);
     void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t senderID);
 #else
-    void union_request(long int v, long int w);
-    void anchor(int w_arrIdx, long int v, long int path_base_arrIdx);
+    void union_request(uint64_t v, uint64_t w);
+    void anchor(int w_arrIdx, uint64_t v, long int path_base_arrIdx);
 #endif
     void local_path_compression(unionFindVertex *src, uint64_t compressedParent);
     bool check_same_chares(uint64_t v1, uint64_t v2);
     void short_circuit_parent(shortCircuitData scd);
-    void compress_path(int arrIdx, int64_t compressedParent);
+    void compress_path(int arrIdx, uint64_t compressedParent);
     unionFindVertex *return_vertices();
 
     // functions and data structures for finding connected components

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -8,7 +8,7 @@ struct unionFindVertex {
     uint64_t vertexID;
     int64_t parent;
     long int componentNumber = -1;
-    std::vector<long int> need_boss_requests; //request queue for processing need_boss requests
+    std::vector<uint64_t> need_boss_requests; //request queue for processing need_boss requests
     long int findOrAnchorCount = 0;
 
     void pup(PUP::er &p) {
@@ -73,12 +73,12 @@ class UnionFindLib : public CBase_UnionFindLib {
     void find_components(CkCallback cb);
     void boss_count_prefix_done(int totalCount);
     void start_component_labeling();
-    void insertDataNeedBoss(const uint64_t & data);
+    void insertDataNeedBoss(const needBossData & data);
     void insertDataFindBoss(const findBossData & data);
 #ifdef ANCHOR_ALGO
     void insertDataAnchor(const anchorData & data);
 #endif
-    void need_boss(int arrIdx, long int fromID);
+    void need_boss(int arrIdx, uint64_t fromID);
     void set_component(int arrIdx, long int compNum);
     void prune_components(int threshold, CkCallback appReturnCb);
     void perform_pruning();

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -5,8 +5,8 @@
 #include <NDMeshStreamer.h>
 
 struct unionFindVertex {
-    long int vertexID;
-    long int parent;
+    uint64_t vertexID;
+    int64_t parent;
     long int componentNumber = -1;
     std::vector<long int> need_boss_requests; //request queue for processing need_boss requests
     long int findOrAnchorCount = 0;
@@ -41,7 +41,7 @@ class UnionFindLib : public CBase_UnionFindLib {
     int numMyVertices;
     int pathCompressionThreshold = 5;
     int componentPruneThreshold;
-    std::pair<int, int> (*getLocationFromID)(long int vid);
+    std::pair<int, int> (*getLocationFromID)(uint64_t vid);
     int myLocalNumBosses;
     int totalNumBosses;
     CkCallback postComponentLabelingCb;
@@ -50,22 +50,22 @@ class UnionFindLib : public CBase_UnionFindLib {
     UnionFindLib() {}
     UnionFindLib(CkMigrateMessage *m) { }
     static CProxy_UnionFindLib unionFindInit(CkArrayID clientArray, int n);
+    void registerGetLocationFromID(std::pair<int, int> (*gloc)(uint64_t vid));
     void register_phase_one_cb(CkCallback cb);
     void initialize_vertices(unionFindVertex *appVertices, int numVertices);
 #ifndef ANCHOR_ALGO
-    void union_request(long int vid1, long int vid2);
-    void find_boss1(int arrIdx, long int partnerID, long int senderID);
-    void find_boss2(int arrIdx, long int boss1ID, long int senderID);
+    void union_request(uint64_t vid1, uint64_t vid2);
+    void find_boss1(int arrIdx, uint64_t partnerID, uint64_t senderID);
+    void find_boss2(int arrIdx, uint64_t boss1ID, uint64_t senderID);
 #else
     void union_request(long int v, long int w);
     void anchor(int w_arrIdx, long int v, long int path_base_arrIdx);
 #endif
-    void local_path_compression(unionFindVertex *src, long int compressedParent);
-    bool check_same_chares(long int v1, long int v2);
+    void local_path_compression(unionFindVertex *src, uint64_t compressedParent);
+    bool check_same_chares(uint64_t v1, uint64_t v2);
     void short_circuit_parent(shortCircuitData scd);
-    void compress_path(int arrIdx, long int compressedParent);
-    unionFindVertex* return_vertices();
-    void registerGetLocationFromID(std::pair<int, int> (*gloc)(long int v));
+    void compress_path(int arrIdx, int64_t compressedParent);
+    unionFindVertex *return_vertices();
 
     // functions and data structures for finding connected components
 

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -47,8 +47,11 @@ class UnionFindLib : public CBase_UnionFindLib {
     CkCallback postComponentLabelingCb;
 
     public:
-    UnionFindLib() {}
+    UnionFindLib() {
+        CkPrintf("Creating element %d on %d\n",thisIndex,CkMyPe());
+    }
     UnionFindLib(CkMigrateMessage *m) { }
+    void passLibGroupID(CkGroupID lgid, CProxy_Prefix pla);
     static CProxy_UnionFindLib unionFindInit(CkArrayID clientArray, int n);
     void registerGetLocationFromID(std::pair<int, int> (*gloc)(uint64_t vid));
     void register_phase_one_cb(CkCallback cb);

--- a/unionFindLib.h
+++ b/unionFindLib.h
@@ -47,9 +47,7 @@ class UnionFindLib : public CBase_UnionFindLib {
     CkCallback postComponentLabelingCb;
 
     public:
-    UnionFindLib() {
-        CkPrintf("Creating element %d on %d\n",thisIndex,CkMyPe());
-    }
+    UnionFindLib() {}
     UnionFindLib(CkMigrateMessage *m) { }
     void passLibGroupID(CkGroupID lgid, CProxy_Prefix pla);
     static CProxy_UnionFindLib unionFindInit(CkArrayID clientArray, int n);


### PR DESCRIPTION
Added functionality to work with Paratreet friends-of-friends implementation. Also added broadcasts to set the read only proxy variables, in case the unionFindLib array is not created in the MainChare's constructor. Finally, removed TRAM, which didn't seem to be working. 